### PR TITLE
fix(lgtm): specified kind version to 1.31.1 due to cgroupv1 issue

### DIFF
--- a/labs/grafana/distributed/config/kind.yaml
+++ b/labs/grafana/distributed/config/kind.yaml
@@ -3,6 +3,10 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: kubelab
 nodes:
 - role: control-plane
+  image: kindest/node:v1.31.1
 - role: worker
+  image: kindest/node:v1.31.1
 - role: worker
+  image: kindest/node:v1.31.1
 - role: worker
+  image: kindest/node:v1.31.1


### PR DESCRIPTION
- https://kubernetes.io/blog/2024/08/14/kubernetes-1-31-moving-cgroup-v1-support-maintenance-mode/
- restricting the kind cluster version for cgroup v1 compatibility